### PR TITLE
Add github pages

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,33 @@
+name: publish github pages
+on:
+  push:
+    tags:
+      - "*"
+  workflow_dispatch:
+
+jobs:
+  publish-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v15
+        with:
+          install_url: https://nixos.org/nix/install
+          extra_nix_config: |
+            access-tokens = github=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build package
+        run:
+          nix build .#static-files
+
+      - name: deploy to pages
+        if: success()
+        uses: crazy-max/ghaction-github-pages@v3
+        with:
+          target_branch: gh-pages
+          build_dir: result/public
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,42 @@
+name: Release
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  publish-github:
+    name: publish to github releases
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v15
+        with:
+          extra_nix_config: |
+            access-tokens = github=${{ secrets.GITHUB_TOKEN }}
+            extra-substituers = https://cache.garnix.io
+            extra-trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=
+
+      - name: get version
+        id: get-version
+        run: |
+          VERSION=`git describe --tags $(git rev-list --tags --max-count=1)`
+          echo ::set-output name=version::"$VERSION"
+
+      - name: generate changelog
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
+        run: |
+          nix develop -c cog changelog --at $VERSION -t full_hash > GITHUB_CHANGELOG.md
+
+      - name: generate release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: GITHUB_CHANGELOG.md
+          tag_name: ${{ steps.get-version.outputs.version }}

--- a/bomp.ron
+++ b/bomp.ron
@@ -1,0 +1,3 @@
+(
+    cargo: Some(Autodetect),
+)

--- a/cog.toml
+++ b/cog.toml
@@ -1,0 +1,23 @@
+ignore_merge_commits = false
+branch_whitelist = ["main"]
+pre_bump_hooks = [
+    "bomper {{latest}} {{version}}"
+]
+post_bump_hooks = [
+    "git push",
+    "git push origin {{version}}"
+]
+
+[commit_types]
+
+[changelog]
+path = "CHANGELOG.md"
+template = "remote"
+remote = "github.com"
+repository = "cheesecalc"
+owner = "justinrubek"
+authors = [
+    { signature = "Justin Rubek", username = "justinrubek" }
+]
+
+[bump_profiles]


### PR DESCRIPTION
This adds a few actions that are used when releasing a new version. GitHub pages will be used to host the web version of the calculator